### PR TITLE
Changes APT repositories to mirrors.ubuntu.com

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,13 @@
 # vi: set ft=ruby :
 
 update = <<SCRIPT
-echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)           main restricted universe multiverse" >  /etc/apt/sources.list
-echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-updates   main restricted universe multiverse" >> /etc/apt/sources.list
-echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-backports main restricted universe multiverse" >> /etc/apt/sources.list
-echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-security  main restricted universe multiverse" >> /etc/apt/sources.list
+if ! grep -q 'mirror://' /etc/apt/sources.list; then
+  echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)           main restricted universe multiverse" >  /etc/apt/sources.list
+  echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-updates   main restricted universe multiverse" >> /etc/apt/sources.list
+  echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-backports main restricted universe multiverse" >> /etc/apt/sources.list
+  echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-security  main restricted universe multiverse" >> /etc/apt/sources.list
+  apt-get update
+fi
 SCRIPT
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,11 +2,10 @@
 # vi: set ft=ruby :
 
 update = <<SCRIPT
-if [ ! -f /tmp/up ]; then
-  sudo sed -i.bak s/us.archive/il.archive/g /etc/apt/sources.list
-  sudo aptitude update 
-  touch /tmp/up
-fi
+echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)           main restricted universe multiverse" >  /etc/apt/sources.list
+echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-updates   main restricted universe multiverse" >> /etc/apt/sources.list
+echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-backports main restricted universe multiverse" >> /etc/apt/sources.list
+echo "deb mirror://mirrors.ubuntu.com/mirrors.txt $(lsb_release -cs)-security  main restricted universe multiverse" >> /etc/apt/sources.list
 SCRIPT
 
 


### PR DESCRIPTION
Instead of hardcoding your country, you can set it to auto-select from the best mirror.
